### PR TITLE
[E-798] Disabling rewards when no budget

### DIFF
--- a/src/pages/ProjectDetails/Contributors/ContributorsTable/View.tsx
+++ b/src/pages/ProjectDetails/Contributors/ContributorsTable/View.tsx
@@ -46,7 +46,7 @@ export default function View({
   remainingBudget,
   onRewardGranted: onPaymentRequested,
 }: Props) {
-  const isSendingNewPaymentDisabled = remainingBudget < rates.hours;
+  const isSendingNewPaymentDisabled = remainingBudget < rates.hours || remainingBudget === 0;
 
   const [sorting, setSorting] = useState({
     field: isProjectLeader ? Field.ToRewardCount : Field.ContributionCount,

--- a/src/pages/ProjectDetails/Contributors/index.tsx
+++ b/src/pages/ProjectDetails/Contributors/index.tsx
@@ -12,6 +12,8 @@ import { ProjectRewardsRoutePaths, ProjectRoutePaths, RoutePaths } from "src/App
 import { viewportConfig } from "src/config";
 import { useMediaQuery } from "usehooks-ts";
 import ProjectLeadInvitation from "src/components/ProjectLeadInvitation/ProjectLeadInvitation";
+import { withTooltip } from "src/components/Tooltip";
+import { rates } from "src/hooks/useWorkEstimation";
 
 export default function Contributors() {
   const { T } = useIntl();
@@ -26,6 +28,7 @@ export default function Contributors() {
   const { data: projectDetails } = useGetProjectDetailsQuery({ variables: { projectId }, ...contextWithCacheHeaders });
 
   const remainingBudget = projectDetails?.projects[0]?.usdBudget?.remainingAmount;
+  const isRewardDisabled = remainingBudget < rates.hours || remainingBudget === 0;
 
   return (
     <>
@@ -35,6 +38,7 @@ export default function Contributors() {
           {isProjectLeader && (
             <Button
               size={ButtonSize.Sm}
+              disabled={isRewardDisabled}
               onClick={() =>
                 navigate(
                   generatePath(
@@ -45,6 +49,9 @@ export default function Contributors() {
                   )
                 )
               }
+              {...withTooltip(T("contributor.table.noBudgetLeft"), {
+                visible: isRewardDisabled,
+              })}
             >
               {isSm ? T("project.rewardButton.full") : T("project.rewardButton.short")}
             </Button>

--- a/src/pages/ProjectDetails/Rewards/RewardForm/WorkEstimation/View.tsx
+++ b/src/pages/ProjectDetails/Rewards/RewardForm/WorkEstimation/View.tsx
@@ -1,6 +1,7 @@
 import Button, { ButtonSize, ButtonType, Width } from "src/components/Button";
 import Card from "src/components/Card";
-import { Steps } from "src/hooks/useWorkEstimation";
+import { withTooltip } from "src/components/Tooltip";
+import { Steps, rates } from "src/hooks/useWorkEstimation";
 import Add from "src/icons/Add";
 import Subtract from "src/icons/Subtract";
 import BudgetBar from "src/pages/ProjectDetails/Rewards/RewardForm/WorkEstimation/BudgetBar";
@@ -31,6 +32,7 @@ export default function WorkEstimation({
   steps,
 }: Props) {
   const { T } = useT();
+  const isRewardDisbled = budget.remainingAmount < rates.hours || budget.remainingAmount === 0;
 
   return (
     <Card padded={false}>
@@ -81,8 +83,11 @@ export default function WorkEstimation({
           <Button
             htmlType="submit"
             width={Width.Full}
-            disabled={requestNewPaymentMutationLoading}
+            disabled={requestNewPaymentMutationLoading || isRewardDisbled}
             data-testid="give-reward-button"
+            {...withTooltip(T("project.details.tableFallback.disabledButtonTooltip"), {
+              visible: isRewardDisbled,
+            })}
           >
             <span>{T("reward.form.confirm")}</span>
           </Button>


### PR DESCRIPTION
<img width="661" alt="Capture d’écran 2023-10-02 à 17 12 38" src="https://github.com/onlydustxyz/marketplace-frontend/assets/31901905/8cb772e2-27e6-4c9d-88ca-42e7ca7486c0">

- [x] Disabled rewards buttons when not enough budget
- [x] Display tooltips when buttons are disabled