### PR TITLE
Currency component - E-696 && E-695

### DIFF
--- a/src/components/Currency/AvailableConversion.tsx
+++ b/src/components/Currency/AvailableConversion.tsx
@@ -1,11 +1,12 @@
 import { FC, useMemo } from "react";
 import { Chip } from "src/components/Chip/Chip";
-import Tooltip, { TooltipPosition, Variant } from "src/components/Tooltip";
 import { Currency } from "src/types";
 import { CurrencyIcons } from "./CurrencyIcon";
 import { Chips } from "src/components/Chips/Chips";
 import { BudgetCurrencyType, formatMoneyAmount } from "src/utils/money";
 import { useIntl } from "src/hooks/useIntl";
+import Tooltip from "src/components/Tooltip";
+import { TooltipPosition, Variant } from "src/components/Tooltip";
 
 // TODO : doc
 /**
@@ -32,7 +33,7 @@ const ConversionAmount = ({ amount, currency }: { amount: number | undefined; cu
   }
 
   return (
-    <p className="text-body-s-bold leading-[14px]">
+    <p className="text-body-s leading-[14px]">
       {formatMoneyAmount({ amount: amount, currency: currency || Currency.USD })}
     </p>
   );
@@ -44,7 +45,7 @@ const ConversionDollar = ({ dollar }: { dollar: number | undefined }) => {
   }
 
   return (
-    <p className="font-walsheim text-[10px] text-spaceBlue-200">
+    <p className="font-walsheim text-xs text-spaceBlue-200">
       {`~${formatMoneyAmount({ amount: dollar, currency: Currency.USD })}`}
     </p>
   );
@@ -79,7 +80,7 @@ const ConversionTooltip = ({
                     {formatMoneyAmount({ amount: currency.amount, currency: currency.currency })}
                   </p>
                   {currency.currency !== Currency.USD && (
-                    <p className="font-walsheim text-[10px] text-spaceBlue-200">
+                    <p className="font-walsheim text-xs text-spaceBlue-200">
                       {currency.dollar
                         ? `~${formatMoneyAmount({ amount: currency.dollar, currency: Currency.USD })}`
                         : T("availableConversion.tooltip.na")}

--- a/src/components/Currency/AvailableConversion.tsx
+++ b/src/components/Currency/AvailableConversion.tsx
@@ -6,7 +6,7 @@ import { Chips } from "src/components/Chips/Chips";
 import { BudgetCurrencyType, formatMoneyAmount } from "src/utils/money";
 import { useIntl } from "src/hooks/useIntl";
 import Tooltip from "src/components/Tooltip";
-import { TooltipPosition, Variant } from "src/components/Tooltip";
+import { TooltipPosition } from "src/components/Tooltip";
 
 // TODO : doc
 /**
@@ -65,7 +65,7 @@ const ConversionTooltip = ({
   }
 
   return (
-    <Tooltip id={tooltipId} clickable position={TooltipPosition.Top} variant={Variant.Blue}>
+    <Tooltip id={tooltipId} clickable position={TooltipPosition.Top}>
       <div className="flex flex-col gap-2">
         <p className="font-walsheim text-sm font-medium text-white">{T("availableConversion.tooltip.title")}</p>
         {currencies && (

--- a/src/components/Currency/AvailableConversion.tsx
+++ b/src/components/Currency/AvailableConversion.tsx
@@ -115,7 +115,10 @@ export const AvailableConversion: FC<AvailableConversion> = ({
     }
 
     return props;
-  }, [currency]);
+  }, [currency, currencies]);
+
+  const tooltipForCurrency = useMemo(() => (currency ? tooltipIdProps : {}), [currency]);
+  const tooltipForCurrencies = useMemo(() => (currencies ? tooltipIdProps : {}), [currencies]);
 
   const currencyArray = useMemo(() => {
     if (currencies) return currencies;
@@ -129,7 +132,7 @@ export const AvailableConversion: FC<AvailableConversion> = ({
 
   return (
     <>
-      <div {...(currencies ? tooltipIdProps : {})} className="flex flex-row items-center justify-start gap-1">
+      <div {...tooltipForCurrencies} className="flex flex-row items-center justify-start gap-1">
         <Chips number={numberCurencyToShow}>
           {currencyArray?.map(currency => (
             <div key={currency.currency}>
@@ -140,7 +143,7 @@ export const AvailableConversion: FC<AvailableConversion> = ({
           ))}
         </Chips>
         <ConversionAmount amount={totalAmount || currency?.amount} currency={currency?.currency} />
-        <div {...(currency ? tooltipIdProps : {})}>
+        <div {...tooltipForCurrency}>
           <ConversionDollar dollar={currency?.currency !== Currency.USD ? currency?.dollar : undefined} />
         </div>
       </div>

--- a/src/components/Currency/AvailableConversion.tsx
+++ b/src/components/Currency/AvailableConversion.tsx
@@ -32,7 +32,7 @@ const ConversionAmount = ({ amount, currency }: { amount: number | undefined; cu
   }
 
   return (
-    <p className="font-walsheim text-sm font-bold leading-[14px]">
+    <p className="text-body-s-bold leading-[14px]">
       {formatMoneyAmount({ amount: amount, currency: currency || Currency.USD })}
     </p>
   );

--- a/src/components/Currency/AvailableConversion.tsx
+++ b/src/components/Currency/AvailableConversion.tsx
@@ -118,9 +118,6 @@ export const AvailableConversion: FC<AvailableConversion> = ({
     return props;
   }, [currency, currencies]);
 
-  const tooltipForCurrency = useMemo(() => (currency ? tooltipIdProps : {}), [currency]);
-  const tooltipForCurrencies = useMemo(() => (currencies ? tooltipIdProps : {}), [currencies]);
-
   const currencyArray = useMemo(() => {
     if (currencies) return currencies;
 
@@ -133,7 +130,7 @@ export const AvailableConversion: FC<AvailableConversion> = ({
 
   return (
     <>
-      <div {...tooltipForCurrencies} className="flex flex-row items-center justify-start gap-1">
+      <div {...(currencies ? tooltipIdProps : {})} className="flex flex-row items-center justify-start gap-1">
         <Chips number={numberCurencyToShow}>
           {currencyArray?.map(currency => (
             <div key={currency.currency}>
@@ -144,7 +141,7 @@ export const AvailableConversion: FC<AvailableConversion> = ({
           ))}
         </Chips>
         <ConversionAmount amount={totalAmount || currency?.amount} currency={currency?.currency} />
-        <div {...tooltipForCurrency}>
+        <div {...(currency ? tooltipIdProps : {})}>
           <ConversionDollar dollar={currency?.currency !== Currency.USD ? currency?.dollar : undefined} />
         </div>
       </div>

--- a/src/components/Currency/AvailableConversion.tsx
+++ b/src/components/Currency/AvailableConversion.tsx
@@ -129,7 +129,7 @@ export const AvailableConversion: FC<AvailableConversion> = ({
 
   return (
     <>
-      <div {...tooltipIdProps} className="flex flex-row items-center justify-start gap-1">
+      <div {...(currencies ? tooltipIdProps : {})} className="flex flex-row items-center justify-start gap-1">
         <Chips number={numberCurencyToShow}>
           {currencyArray?.map(currency => (
             <div key={currency.currency}>
@@ -140,7 +140,9 @@ export const AvailableConversion: FC<AvailableConversion> = ({
           ))}
         </Chips>
         <ConversionAmount amount={totalAmount || currency?.amount} currency={currency?.currency} />
-        <ConversionDollar dollar={currency?.currency !== Currency.USD ? currency?.dollar : undefined} />
+        <div {...(currency ? tooltipIdProps : {})}>
+          <ConversionDollar dollar={currency?.currency !== Currency.USD ? currency?.dollar : undefined} />
+        </div>
       </div>
       <ConversionTooltip tooltipId={tooltipId} currencies={currencies} />
     </>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -276,7 +276,7 @@ const config: Config = {
         ".text-body-l-bold": {
           fontSize: "18px",
           fontFamily: theme("fontFamily.walsheim"),
-          fontWeight: "600",
+          fontWeight: "500",
           lineHeight: "24px",
           letterSpacing: "-0.18px",
         },
@@ -292,7 +292,7 @@ const config: Config = {
           lineHeight: "20px",
           letterSpacing: "-0.16px",
           fontFamily: theme("fontFamily.walsheim"),
-          fontWeight: "600",
+          fontWeight: "500",
         },
         ".text-body-s": {
           fontSize: "14px",
@@ -306,7 +306,7 @@ const config: Config = {
           lineHeight: "16px",
           letterSpacing: "-0.14px",
           fontFamily: theme("fontFamily.walsheim"),
-          fontWeight: "600",
+          fontWeight: "500",
         },
         ".text-body-xs": {
           fontSize: "12px",
@@ -320,7 +320,7 @@ const config: Config = {
           lineHeight: "16px",
           letterSpacing: "-0.12px",
           fontFamily: theme("fontFamily.walsheim"),
-          fontWeight: "600",
+          fontWeight: "500",
         },
         /* ---------------------------------- CARD ---------------------------------- */
         ".card-light": {


### PR DESCRIPTION
- Reduce font-weight for total in$ it's too bold
- dollar equivalent tootip should be displayed (and centered) when hovering dollars, not other currency amount 
- can you increase font size for dollar equivalent within tooltip