### PR TITLE
Add unregister panel function and hooks

### DIFF
--- a/src/App/Stacks/GithubWorkflow/ClaimSidePanel/claim.utils.ts
+++ b/src/App/Stacks/GithubWorkflow/ClaimSidePanel/claim.utils.ts
@@ -17,16 +17,16 @@ export namespace ClaimUtils {
     project?: UseGetProjectBySlugResponse;
     organizations?: UseGithubOrganizationsResponse[];
   }) => {
-    if (!canDisplay({ project })) {
+    if (!organizations || !canDisplay({ project })) {
       return false;
     }
 
     const isAllOrganizationInstalled = project?.organizations?.every(org => {
-      if (org.installed) {
+      if (org.installed && organizations?.find(myOrg => myOrg.githubUserId === org.githubUserId && myOrg.installed)) {
         return true;
       }
 
-      return !!organizations?.find(myOrg => myOrg.githubUserId === org.githubUserId && myOrg.installed);
+      return false;
     });
 
     return isAllOrganizationInstalled || false;

--- a/src/libs/react-stack/components/RegisterStack.tsx
+++ b/src/libs/react-stack/components/RegisterStack.tsx
@@ -3,9 +3,7 @@ import useStackRegister from "../hooks/useStackRegister";
 import { RegisterStackProps, StacksParams } from "../types/Stack";
 import { Stack } from "./Stack";
 
-export function RegisterStack<P extends StacksParams>(
-  props: RegisterStackProps<P> & { unRegisterOnUnMount?: boolean }
-) {
+export function RegisterStack<P extends StacksParams>(props: RegisterStackProps<P>) {
   const ref = useStackRegister(props);
 
   return <Stack stackRef={ref} />;

--- a/src/libs/react-stack/components/RegisterStack.tsx
+++ b/src/libs/react-stack/components/RegisterStack.tsx
@@ -3,7 +3,9 @@ import useStackRegister from "../hooks/useStackRegister";
 import { RegisterStackProps, StacksParams } from "../types/Stack";
 import { Stack } from "./Stack";
 
-export function RegisterStack<P extends StacksParams>(props: RegisterStackProps<P>) {
+export function RegisterStack<P extends StacksParams>(
+  props: RegisterStackProps<P> & { unRegisterOnUnMount?: boolean }
+) {
   const ref = useStackRegister(props);
 
   return <Stack stackRef={ref} />;

--- a/src/libs/react-stack/context/stack.context.provider.tsx
+++ b/src/libs/react-stack/context/stack.context.provider.tsx
@@ -86,6 +86,16 @@ export default function ReactStackprovider({ children }: reactStackContextProps)
     }
   };
 
+  const unRegisterStack = (name: string) => {
+    if (stacks.state[name]) {
+      setStacks(prev => {
+        const newState = { ...prev };
+        delete newState[name];
+        return newState;
+      });
+    }
+  };
+
   /* -------------------------------------------------------------------------- */
   /*                            PANEL REF MANAGEMENT                            */
   /* -------------------------------------------------------------------------- */
@@ -420,6 +430,7 @@ export default function ReactStackprovider({ children }: reactStackContextProps)
         history: historyStore,
         stackMethods: {
           register: registerStack,
+          unRegister: unRegisterStack,
           closeAll,
           closeLast: onCloseLastPanel,
           getStack,

--- a/src/libs/react-stack/context/stack.context.ts
+++ b/src/libs/react-stack/context/stack.context.ts
@@ -10,6 +10,7 @@ export const ReactStackContext = createContext<IReactStackContext>({
   stackMethods: {
     closeAll: () => null,
     register: () => null,
+    unRegister: () => null,
     getStack: () => null,
     getPanel: () => null,
     open: () => null,

--- a/src/libs/react-stack/context/stack.context.type.ts
+++ b/src/libs/react-stack/context/stack.context.type.ts
@@ -20,6 +20,7 @@ export type IReactStackContext = {
   stackMethods: {
     closeAll: () => void;
     register: (stack: RefSubscriptionInterface<StackInterface<AnyParams>>) => void;
+    unRegister: (name: string) => void;
     getStack: (name: string) => RefSubscriptionInterface<StackInterface<AnyParams>> | null;
     getPanel: (name: string, id: string) => RefSubscriptionInterface<StackPanelInterface> | null;
     open: (name: string, params?: StacksParams) => void;

--- a/src/libs/react-stack/hooks/useStackRegister.ts
+++ b/src/libs/react-stack/hooks/useStackRegister.ts
@@ -11,10 +11,7 @@ import useStackContext from "./useStackContext";
  * @param {RegisterStackProps<P>} props - The props for registering the stack.
  * @returns {StackInterface<P>} - The registered stack.
  */
-export const useStackRegister = <P extends StacksParams>({
-  unRegisterOnUnMount,
-  ...props
-}: RegisterStackProps<P> & { unRegisterOnUnMount?: boolean }) => {
+export const useStackRegister = <P extends StacksParams>({ unRegisterOnUnMount, ...props }: RegisterStackProps<P>) => {
   const {
     stackMethods: { register, getStack, unRegister },
   } = useStackContext();

--- a/src/libs/react-stack/hooks/useStackRegister.ts
+++ b/src/libs/react-stack/hooks/useStackRegister.ts
@@ -52,7 +52,7 @@ export const useStackRegister = <P extends StacksParams>({
     }
   }, [stack]);
 
-  /** un register on un mount */
+  /** un register on unMount */
   useEffect(() => {
     return () => {
       if (unRegisterOnUnMount) {

--- a/src/libs/react-stack/hooks/useStackRegister.ts
+++ b/src/libs/react-stack/hooks/useStackRegister.ts
@@ -11,10 +11,14 @@ import useStackContext from "./useStackContext";
  * @param {RegisterStackProps<P>} props - The props for registering the stack.
  * @returns {StackInterface<P>} - The registered stack.
  */
-export const useStackRegister = <P extends StacksParams>(props: RegisterStackProps<P>) => {
+export const useStackRegister = <P extends StacksParams>({
+  unRegisterOnUnMount,
+  ...props
+}: RegisterStackProps<P> & { unRegisterOnUnMount?: boolean }) => {
   const {
-    stackMethods: { register, getStack },
+    stackMethods: { register, getStack, unRegister },
   } = useStackContext();
+
   const [templatePanel] = useRefSubscription<StackPanelInterface<P>>({
     open: false,
     position: "hidden",
@@ -46,6 +50,15 @@ export const useStackRegister = <P extends StacksParams>(props: RegisterStackPro
     if (!getStack(stack.state.name)) {
       register(stack);
     }
+  }, [stack]);
+
+  /** un register on un mount */
+  useEffect(() => {
+    return () => {
+      if (unRegisterOnUnMount) {
+        unRegister(props.name);
+      }
+    };
   }, [stack]);
 
   return stack;

--- a/src/libs/react-stack/hooks/useStackUnRegister.ts
+++ b/src/libs/react-stack/hooks/useStackUnRegister.ts
@@ -1,0 +1,14 @@
+import useStackContext from "./useStackContext";
+
+/**
+ * Custom hook for un registering a stack.
+ */
+export const useStackUnRegister = () => {
+  const {
+    stackMethods: { unRegister },
+  } = useStackContext();
+
+  return unRegister;
+};
+
+export default useStackUnRegister;

--- a/src/libs/react-stack/types/Stack.ts
+++ b/src/libs/react-stack/types/Stack.ts
@@ -110,4 +110,4 @@ export interface StacksInterface<P extends StacksParams = StacksParams> {
  * @param {P} props - The props for the stack.
  * @returns {StackOptionalInterface<P>} - The registered stack props.
  */
-export type RegisterStackProps<P extends StacksParams> = StackOptionalInterface<P>;
+export type RegisterStackProps<P extends StacksParams> = StackOptionalInterface<P> & { unRegisterOnUnMount?: boolean };

--- a/src/pages/ProjectDetails/ProjectEdition/components/Panel/context.tsx
+++ b/src/pages/ProjectDetails/ProjectEdition/components/Panel/context.tsx
@@ -1,7 +1,8 @@
-import { createContext, useCallback, useEffect, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
 import { EDIT_PANEL_NAME, EditPanel } from ".";
 import { UseGetProjectBySlugResponse } from "src/api/Project/queries";
 import { useStackNavigation } from "src/libs/react-stack";
+import { EditContext } from "../../EditContext";
 
 interface EditPanelContextProps {
   openOnLoad: boolean;
@@ -41,7 +42,8 @@ export const EditPanelContext = createContext<EditPanelType>({
 
 export function EditPanelProvider({ children, openOnLoad, isLoading }: EditPanelContextProps) {
   const [activeTab, setActiveTab] = useState<TabsType>(TabsType.Repos);
-  const [openSidePanel, closeSidePanel] = useStackNavigation(EDIT_PANEL_NAME);
+  const { project } = useContext(EditContext);
+  const [openSidePanel, closeSidePanel] = useStackNavigation(EDIT_PANEL_NAME(project?.id || ""));
 
   const toggleSidePanel = useCallback((value: boolean) => {
     if (value) {

--- a/src/pages/ProjectDetails/ProjectEdition/components/Panel/index.tsx
+++ b/src/pages/ProjectDetails/ProjectEdition/components/Panel/index.tsx
@@ -14,7 +14,7 @@ function TabContents({ children }: PropsWithChildren) {
   return <Flex className="items-center gap-2 md:gap-1.5">{children}</Flex>;
 }
 
-export const EDIT_PANEL_NAME = (id: string) => `project-edit-pane-${id}`;
+export const EDIT_PANEL_NAME = (id: string) => `project-edit-panel-${id}`;
 
 export const SafeEditPanel = () => {
   const { T } = useIntl();

--- a/src/pages/ProjectDetails/ProjectEdition/components/Panel/index.tsx
+++ b/src/pages/ProjectDetails/ProjectEdition/components/Panel/index.tsx
@@ -8,12 +8,13 @@ import { useIntl } from "src/hooks/useIntl";
 import GlobalLine from "src/icons/GlobalLine";
 import { Tabs } from "src/components/Tabs/Tabs";
 import { RegisterStack } from "src/libs/react-stack";
+import { EditContext } from "../../EditContext";
 
 function TabContents({ children }: PropsWithChildren) {
   return <Flex className="items-center gap-2 md:gap-1.5">{children}</Flex>;
 }
 
-export const EDIT_PANEL_NAME = "project-edit-panel";
+export const EDIT_PANEL_NAME = (id: string) => `project-edit-pane-${id}`;
 
 export const SafeEditPanel = () => {
   const { T } = useIntl();
@@ -76,5 +77,10 @@ export const SafeEditPanel = () => {
 };
 
 export const EditPanel = () => {
-  return <RegisterStack name={EDIT_PANEL_NAME}>{() => <SafeEditPanel />}</RegisterStack>;
+  const { project } = useContext(EditContext);
+  return (
+    <RegisterStack unRegisterOnUnMount name={EDIT_PANEL_NAME(project?.id || "")}>
+      {() => <SafeEditPanel />}
+    </RegisterStack>
+  );
 };


### PR DESCRIPTION
Why ? on the edit context we use a dynamique panel context, the issue was when we open the panel on the edit project for the first it's work because the panel was not already registered in the stacks store but when go back and try to open the same panel in an another project we can't. 

I added an unregister function to remove a panel from the stack store