### PR TITLE
E 934 tooltip not shown when hovering organisations i cannot edit

### DIFF
--- a/src/pages/ProjectDetails/ProjectEdition/components/Panel/OrganizationTab/EditPanelOrganization.tsx
+++ b/src/pages/ProjectDetails/ProjectEdition/components/Panel/OrganizationTab/EditPanelOrganization.tsx
@@ -29,6 +29,7 @@ export const EditPanelOrganization = () => {
           <OrganizationList
             organizations={installedOrganizations}
             emptyListFallBackText={T("project.details.create.organizations.installedOrganizationEmpty")}
+            disabledTooltip={T("project.details.create.organizations.tooltipInstalledByAdmin")}
           />
         </Card>
 

--- a/src/pages/ProjectDetails/ProjectEdition/components/Panel/OrganizationTab/components/OrganizationList.tsx
+++ b/src/pages/ProjectDetails/ProjectEdition/components/Panel/OrganizationTab/components/OrganizationList.tsx
@@ -9,9 +9,14 @@ import { getGithubSetupLink } from "src/utils/githubSetupLink";
 interface OrganizationListProps {
   organizations: UseGithubOrganizationsResponse[];
   emptyListFallBackText: string;
+  disabledTooltip?: string;
 }
 
-export default function OrganizationList({ organizations, emptyListFallBackText }: OrganizationListProps) {
+export default function OrganizationList({
+  organizations,
+  emptyListFallBackText,
+  disabledTooltip,
+}: OrganizationListProps) {
   const {
     githubWorklow: { run },
     project,
@@ -40,6 +45,7 @@ export default function OrganizationList({ organizations, emptyListFallBackText 
               linkIcon={org.installed ? <PencilLine /> : <AddLine />}
               isExternalFlow={org.installed}
               disabled={!org.isCurrentUserAdmin}
+              tooltip={disabledTooltip}
             />
           );
         })}


### PR DESCRIPTION
e-934-tooltip-not-shown-when-hovering-organisations-i-cannot-edit